### PR TITLE
Infer digest/signature algos from public key type instead of cert sig

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -1,12 +1,19 @@
 package cms
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+
 	"github.com/mastahyeti/fakeca"
 )
 
 var (
-	root         = fakeca.New(fakeca.IsCA)
-	intermediate = root.Issue(fakeca.IsCA)
-	leaf         = intermediate.Issue()
-	otherRoot    = fakeca.New(fakeca.IsCA)
+	root = fakeca.New(fakeca.IsCA)
+
+	intermediateKey, _ = ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	intermediate       = root.Issue(fakeca.IsCA, fakeca.PrivateKey(intermediateKey))
+
+	leaf      = intermediate.Issue()
+	otherRoot = fakeca.New(fakeca.IsCA)
 )


### PR DESCRIPTION
I had been mistakenly inferring signature/digest algorithms from the signature on the certificate. This is totally wrong, since the issuer might use different algorithms than the subject. With this PR, we take an opinionated stance on which digest algorithm to use. We default to SHA256, except for EC curves P384 and P521 which use SHA384 and SHA512 respectively. These algorithms were chosen to match those used by the x509 package [here](https://github.com/golang/go/blob/7ba1c91dd999681425c2e1053b854f218ea3f2f8/src/crypto/x509/x509.go#L1972).

/cc @ptoomey3 who pointed out this behavior