### PR TITLE
Methods for getting/setting certificates from SignedData

### DIFF
--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -595,7 +595,7 @@ func (sd *SignedData) AddSignerInfo(chain []*x509.Certificate, signer crypto.Sig
 	)
 
 	for _, c := range chain {
-		if err = sd.addCertificate(c); err != nil {
+		if err = sd.AddCertificate(c); err != nil {
 			return err
 		}
 
@@ -697,8 +697,13 @@ func digestAlgorithmForPublicKey(pub crypto.PublicKey) pkix.AlgorithmIdentifier 
 	return pkix.AlgorithmIdentifier{Algorithm: oid.DigestAlgorithmSHA256}
 }
 
-// addCertificate adds a *x509.Certificate.
-func (sd *SignedData) addCertificate(cert *x509.Certificate) error {
+// ClearCertificates removes all certificates.
+func (sd *SignedData) ClearCertificates() {
+	sd.Certificates = []asn1.RawValue{}
+}
+
+// AddCertificate adds a *x509.Certificate.
+func (sd *SignedData) AddCertificate(cert *x509.Certificate) error {
 	for _, existing := range sd.Certificates {
 		if bytes.Equal(existing.Bytes, cert.Raw) {
 			return errors.New("certificate already added")

--- a/signed_data.go
+++ b/signed_data.go
@@ -1,6 +1,7 @@
 package cms
 
 import (
+	"crypto/x509"
 	"encoding/asn1"
 
 	"github.com/mastahyeti/cms/protocol"
@@ -46,6 +47,23 @@ func ParseSignedData(ber []byte) (*SignedData, error) {
 // the SignedData encapsulates something other than data (1.2.840.113549.1.7.1).
 func (sd *SignedData) GetData() ([]byte, error) {
 	return sd.psd.EncapContentInfo.DataEContent()
+}
+
+// GetCertificates gets all the certificates stored in the SignedData.
+func (sd *SignedData) GetCertificates() ([]*x509.Certificate, error) {
+	return sd.psd.X509Certificates()
+}
+
+// SetCertificates replaces the certificates stored in the SignedData with new
+// ones.
+func (sd *SignedData) SetCertificates(certs []*x509.Certificate) error {
+	sd.psd.ClearCertificates()
+	for _, cert := range certs {
+		if err := sd.psd.AddCertificate(cert); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // Detached removes the data content from this SignedData. No more signatures


### PR DESCRIPTION
Other S/MIME libraries (at least gpgsm) allow the user to not include any certificates in the SignedData.