### PR TITLE
Use UTC for SigningTime attribute

### DIFF
--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -670,7 +670,7 @@ func (sd *SignedData) AddSignerInfo(chain []*x509.Certificate, signer crypto.Sig
 	}
 
 	// Build our SignedAttributes
-	stAttr, err := NewAttribute(oid.AttributeSigningTime, time.Now())
+	stAttr, err := NewAttribute(oid.AttributeSigningTime, time.Now().UTC())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This is required for interoperability with gpgsm.