### PR TITLE
Add mapping from algo OID to x509 SignatureAlgorithm for DSAWithSHA1

### DIFF
--- a/oid/oid.go
+++ b/oid/oid.go
@@ -121,6 +121,7 @@ var SignatureAlgorithmToX509SignatureAlgorithm = map[string]x509.SignatureAlgori
 	SignatureAlgorithmECDSAWithSHA256.String(): x509.ECDSAWithSHA256,
 	SignatureAlgorithmECDSAWithSHA384.String(): x509.ECDSAWithSHA384,
 	SignatureAlgorithmECDSAWithSHA512.String(): x509.ECDSAWithSHA512,
+	SignatureAlgorithmDSAWithSHA1.String():     x509.DSAWithSHA1,
 }
 
 // X509PublicKeyAlgorithmToPKIXAlgorithmIdentifier maps certificate public key


### PR DESCRIPTION
This is preventing me from using this library to validate pkcs7 formatted AWS instance identity documents. See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-identity-documents.html