### PR TITLE
Return ASN1Error with specific errors instead of ErrUnsupported

### DIFF
--- a/protocol/protocol_test.go
+++ b/protocol/protocol_test.go
@@ -354,8 +354,8 @@ func testParseContentInfo(t *testing.T, ber []byte) {
 			t.Fatal("nil/empty message digest attribute")
 		}
 
-		if algo := si.X509SignatureAlgorithm(); algo == x509.UnknownSignatureAlgorithm {
-			t.Fatalf("unknown signature algorithm")
+		if _, err := si.X509SignatureAlgorithm(); err != nil {
+			t.Fatalf(err.Error())
 		}
 
 		var nilTime time.Time

--- a/timestamp.go
+++ b/timestamp.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"crypto/x509"
 	"errors"
+	"fmt"
 
 	"github.com/mastahyeti/cms/oid"
 	"github.com/mastahyeti/cms/protocol"
@@ -94,7 +95,9 @@ func getTimestamp(si protocol.SignerInfo, opts x509.VerifyOptions) (timestamp.In
 	}
 
 	if tsti.Version != 1 {
-		return timestamp.Info{}, protocol.ErrUnsupported
+		return timestamp.Info{}, protocol.ASN1Error{
+			Message: fmt.Sprintf("Timestamp version %d not supported", tsti.Version),
+		}
 	}
 
 	// verify timestamp signature and certificate chain..

--- a/timestamp/timestamp_test.go
+++ b/timestamp/timestamp_test.go
@@ -3,7 +3,6 @@ package timestamp
 import (
 	"bytes"
 	"crypto"
-	"crypto/x509"
 	"encoding/asn1"
 	"encoding/base64"
 	"encoding/hex"
@@ -421,8 +420,8 @@ func testParseInfo(t *testing.T, ber []byte) {
 			t.Fatal("nil/empty message digest attribute")
 		}
 
-		if algo := si.X509SignatureAlgorithm(); algo == x509.UnknownSignatureAlgorithm {
-			t.Fatalf("unknown signature algorithm")
+		if _, err := si.X509SignatureAlgorithm(); err != nil {
+			t.Fatalf(err.Error())
 		}
 
 		var nilTime time.Time

--- a/verify.go
+++ b/verify.go
@@ -125,9 +125,9 @@ func (sd *SignedData) verify(econtent []byte, opts x509.VerifyOptions) ([][][]*x
 			return nil, err
 		}
 
-		algo := si.X509SignatureAlgorithm()
-		if algo == x509.UnknownSignatureAlgorithm {
-			return nil, protocol.ErrUnsupported
+		algo, err := si.X509SignatureAlgorithm()
+		if err != nil {
+			return nil, protocol.ASN1Error{Message: err.Error()}
 		}
 
 		if err := cert.CheckSignature(algo, signedMessage, si.Signature); err != nil {


### PR DESCRIPTION
This really helps debugging why things aren't working.