### PR TITLE
timestamp_test: Fix CI

### DIFF
--- a/timestamp_test.go
+++ b/timestamp_test.go
@@ -3,6 +3,7 @@ package cms
 import (
 	"crypto/rsa"
 	"crypto/x509"
+	"strings"
 	"testing"
 	"time"
 
@@ -99,7 +100,7 @@ func TestTimestampsVerifications(t *testing.T) {
 	if _, err := getTimestamp(sd.psd.SignerInfos[0], intermediateOpts); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := sd.Verify(intermediateOpts); err == nil || err.Error() != "x509: certificate has expired or is not yet valid" {
+	if _, err := sd.Verify(intermediateOpts); err == nil || !strings.HasPrefix(err.Error(), "x509: certificate has expired") {
 		t.Fatalf("expected expired error, got %v", err)
 	}
 
@@ -137,7 +138,7 @@ func TestTimestampsVerifications(t *testing.T) {
 	if _, err := getTimestamp(sd.psd.SignerInfos[0], intermediateOpts); err != nil {
 		t.Fatal(err)
 	}
-	if _, err := sd.Verify(intermediateOpts); err == nil || err.Error() != "x509: certificate has expired or is not yet valid" {
+	if _, err := sd.Verify(intermediateOpts); err == nil || !strings.HasPrefix(err.Error(), "x509: certificate has expired") {
 		t.Fatalf("expected expired error, got %v", err)
 	}
 


### PR DESCRIPTION
A later version of Go changed the error string for some x509 errors,
causing the CI to fail. Fix the test to just test for an error prefix.

Signed-off-by: Joe Richey <joerichey@google.com>