### PR TITLE
Fix signatureAlgorithm in signerInfos to use correct OIDs.

### DIFF
--- a/oid/oid.go
+++ b/oid/oid.go
@@ -4,7 +4,6 @@ package oid
 import (
 	"crypto"
 	"crypto/x509"
-	"crypto/x509/pkix"
 	"encoding/asn1"
 )
 
@@ -124,9 +123,20 @@ var SignatureAlgorithmToX509SignatureAlgorithm = map[string]x509.SignatureAlgori
 	SignatureAlgorithmDSAWithSHA1.String():     x509.DSAWithSHA1,
 }
 
-// X509PublicKeyAlgorithmToPKIXAlgorithmIdentifier maps certificate public key
-// algorithms to CMS signature algorithms.
-var X509PublicKeyAlgorithmToPKIXAlgorithmIdentifier = map[x509.PublicKeyAlgorithm]pkix.AlgorithmIdentifier{
-	x509.RSA:   pkix.AlgorithmIdentifier{Algorithm: PublicKeyAlgorithmRSA},
-	x509.ECDSA: pkix.AlgorithmIdentifier{Algorithm: PublicKeyAlgorithmECDSA},
+// X509PublicKeyAndDigestAlgorithmToSignatureAlgorithm maps X509 public key and
+// digest algorithms to to SignatureAlgorithm OIDs.
+var X509PublicKeyAndDigestAlgorithmToSignatureAlgorithm = map[x509.PublicKeyAlgorithm]map[string]asn1.ObjectIdentifier{
+	x509.RSA: map[string]asn1.ObjectIdentifier{
+		DigestAlgorithmSHA1.String():   SignatureAlgorithmSHA1WithRSA,
+		DigestAlgorithmMD5.String():    SignatureAlgorithmMD5WithRSA,
+		DigestAlgorithmSHA256.String(): SignatureAlgorithmSHA256WithRSA,
+		DigestAlgorithmSHA384.String(): SignatureAlgorithmSHA384WithRSA,
+		DigestAlgorithmSHA512.String(): SignatureAlgorithmSHA512WithRSA,
+	},
+	x509.ECDSA: map[string]asn1.ObjectIdentifier{
+		DigestAlgorithmSHA1.String():   SignatureAlgorithmECDSAWithSHA1,
+		DigestAlgorithmSHA256.String(): SignatureAlgorithmECDSAWithSHA256,
+		DigestAlgorithmSHA384.String(): SignatureAlgorithmECDSAWithSHA384,
+		DigestAlgorithmSHA512.String(): SignatureAlgorithmECDSAWithSHA512,
+	},
 }

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -659,18 +659,21 @@ func (sd *SignedData) AddSignerInfo(chain []*x509.Certificate, signer crypto.Sig
 		return err
 	}
 
-	digestAlgorithm := digestAlgorithmForPublicKey(pub)
-	signatureAlgorithm, ok := oid.X509PublicKeyAlgorithmToPKIXAlgorithmIdentifier[cert.PublicKeyAlgorithm]
+	digestAlgorithmID := digestAlgorithmForPublicKey(pub)
+
+	signatureAlgorithmOID, ok := oid.X509PublicKeyAndDigestAlgorithmToSignatureAlgorithm[cert.PublicKeyAlgorithm][digestAlgorithmID.Algorithm.String()]
 	if !ok {
 		return errors.New("unsupported certificate public key algorithm")
 	}
 
+	signatureAlgorithmID := pkix.AlgorithmIdentifier{Algorithm: signatureAlgorithmOID}
+
 	si := SignerInfo{
 		Version:            1,
 		SID:                sid,
-		DigestAlgorithm:    digestAlgorithm,
+		DigestAlgorithm:    digestAlgorithmID,
 		SignedAttrs:        nil,
-		SignatureAlgorithm: signatureAlgorithm,
+		SignatureAlgorithm: signatureAlgorithmID,
 		Signature:          nil,
 		UnsignedAttrs:      nil,
 	}


### PR DESCRIPTION
This changes the OID from id-ecPublicKey (1.2.840.10045.2.1)
to ecdsa-with-SHA256 (1.2.840.10045.4.3.2) for ECDSA, for example.

The OID used by `ietf-cms` differs from signatures generated by both `gpgsm`
and `openssl cms`. This PR corrects the OID in signatures generated by `ietf-cms`
(and tools that use it such as `smimesign`) to match the OID used by `gpgsm` and
`openssl cms`.